### PR TITLE
open command did not work with pushinsteadof configuration

### DIFF
--- a/bin/git-review
+++ b/bin/git-review
@@ -440,12 +440,32 @@ openReview() {
     exit 2
   fi
 
-  ssh_url=$($GIT config remote.$REMOTE.url)
-  ssh_url=${ssh_url#ssh://}
-  ssh_url=${ssh_url#*@}
-  ssh_url=${ssh_url%/*}
-  ssh_url=${ssh_url%:*}
-  eval "$BROWSER http://$ssh_url/$CHANGE"
+  gerrit_host=
+  remote_url=$($GIT config remote.$REMOTE.url)
+
+  if [[ $remote_url = ssh://* ]]; then
+    gerrit_host=${remote_url#ssh://}
+    gerrit_host=${gerrit_host#*@}
+    gerrit_host=${gerrit_host%/*}
+    gerrit_host=${gerrit_host%:*}
+  else
+    # probably pushinsteadof config
+    protocol=${remote_url%://*}
+    remote_host=${remote_url#*://}
+    remote_host=${remote_host%%/*}
+    pushinsteadof=$($GIT config -l | grep pushinsteadof=$protocol://$remote_host)
+    if [[ $pushinsteadof ]]; then
+      gerrit_host=${pushinsteadof#*@}
+      gerrit_host=${gerrit_host%%:*}
+    fi
+  fi
+
+  if [[ $gerrit_host ]]; then
+    eval "$BROWSER http://$gerrit_host/$CHANGE"
+  else
+    warn "Could not get the URL of gerrit"
+    exit 2
+  fi
   exit 0
 }
 

--- a/bin/git-review
+++ b/bin/git-review
@@ -324,7 +324,7 @@ approveChange() {
   good "Approving '$LOG'..."
   ssh $host $port gerrit approve \
       --verified=+1 \
-      --code-review=+2 \
+      --code-review=+1 \
       --project=$project $CHANGE,$PATCH ||
     die "Unable to approve the commit"
 }

--- a/bin/git-review
+++ b/bin/git-review
@@ -284,7 +284,7 @@ resetReview() {
 }
 
 approveChange() {
-  local url_line=$($GIT remote show -n origin | grep "URL: " | head -n1)
+  local url_line=$($GIT remote show -n origin | grep "Push  URL: " | head -n1)
   local host_and_project=${url_line# *URL: }
 
   local host

--- a/bin/git-review
+++ b/bin/git-review
@@ -440,28 +440,29 @@ openReview() {
     exit 2
   fi
 
-  gerrit_host=
-  remote_url=$($GIT config remote.$REMOTE.url)
+  local url_line=$($GIT remote show -n origin | grep "Push  URL: " | head -n1)
+  local host_and_project=${url_line# *URL: }
 
-  if [[ $remote_url = ssh://* ]]; then
-    gerrit_host=${remote_url#ssh://}
-    gerrit_host=${gerrit_host#*@}
-    gerrit_host=${gerrit_host%/*}
-    gerrit_host=${gerrit_host%:*}
-  else
-    # probably pushinsteadof config
-    protocol=${remote_url%://*}
-    remote_host=${remote_url#*://}
-    remote_host=${remote_host%%/*}
-    pushinsteadof=$($GIT config -l | grep pushinsteadof=$protocol://$remote_host)
-    if [[ $pushinsteadof ]]; then
-      gerrit_host=${pushinsteadof#*@}
-      gerrit_host=${gerrit_host%%:*}
+  local host
+  local project
+  local port
+
+  if [[ "$host_and_project" =~ "ssh://" ]]; then
+    host_and_project=${host_and_project#ssh://}
+    local host_and_port=${host_and_project%/*}
+
+    if [[ "$host_and_port" =~ ":" ]]; then
+      host=${host_and_port%:*}
+      port=${host_and_port#*:}
+    else
+      host=${host_and_port}
     fi
+  else
+    host=${host_and_project%:*}
   fi
 
-  if [[ $gerrit_host ]]; then
-    eval "$BROWSER http://$gerrit_host/$CHANGE"
+  if [[ $host ]]; then
+    eval "$BROWSER http://$host/$CHANGE"
   else
     warn "Could not get the URL of gerrit"
     exit 2


### PR DESCRIPTION
If your git/gerrit configuration is based on pushInsteadOf, then the
"open" command did not work.

pusinsteadof can be configured as followed:
git config --global
  url."ssh://username@gerrit.example.org:29418".pushInsteadOf
  git://git.example.org
This way, no different url for "push" has to be configured or manually
entered.

Would be nice, if you could integrate this commit!

Thanks for your work - the script is a great help!
Steffe n
